### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/dytsou/reactCounter/security/code-scanning/8](https://github.com/dytsou/reactCounter/security/code-scanning/8)

The best way to fix the issue is to explicitly set a minimal permissions block for the `test` job in `.github/workflows/deploy-gh-pages.yml`. Because the `test` job only runs steps to install dependencies and test the code, it does not need write permission to repository contents, nor any other elevated write permissions. The correct minimal block is `permissions: contents: read`. This should be added between `runs-on:` (line 11) and `steps:` (line 13) of the `test` job. No further imports or method/variable definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
